### PR TITLE
Remove department from player view

### DIFF
--- a/src/components/PlayerRankings.tsx
+++ b/src/components/PlayerRankings.tsx
@@ -23,7 +23,6 @@ const PlayerCard = ({ player, index }: PlayerCardProps) => (
       <span className="text-2xl">{player.avatar}</span>
       <div>
         <div className="font-semibold text-slate-800 text-sm">{player.name}</div>
-        <div className="text-xs text-slate-600">{player.department}</div>
         <div className="text-xs text-slate-500">
           {player.wins}W - {player.losses}L ({player.matchesPlayed} total)
         </div>

--- a/src/components/__tests__/PlayerRankings.test.tsx
+++ b/src/components/__tests__/PlayerRankings.test.tsx
@@ -59,7 +59,6 @@ describe('PlayerRankings', () => {
     expect(screen.getByText('Alice Johnson')).toBeInTheDocument()
     expect(screen.getByText('1500')).toBeInTheDocument()
     expect(screen.getByText('7W - 3L (10 total)')).toBeInTheDocument()
-    expect(screen.getByText('Engineering')).toBeInTheDocument()
   })
 
   test('calculates and displays win rate correctly', () => {


### PR DESCRIPTION
Fixes #3

Removes the department field from the PlayerRankings component to simplify the player view on the rankings screen.

## Changes
- Removed department display from PlayerCard component
- Updated test to remove department field assertion

Generated with [Claude Code](https://claude.ai/code)