### PR TITLE
fix: change Rankings layout from grid to vertical

### DIFF
--- a/src/components/PlayerRankings.tsx
+++ b/src/components/PlayerRankings.tsx
@@ -67,7 +67,7 @@ const PlayerRankings = ({ players, onPlayerClick }: PlayerRankingsProps) => {
       </div>
 
       <div className="p-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div className="flex flex-col gap-2 max-w-4xl mx-auto">
           {sortedPlayers.map((player, index) =>
             onPlayerClick ? (
               <button


### PR DESCRIPTION
This PR fixes the Rankings page layout by changing it from a grid to a vertical list.

## Changes
- Removed grid layout (grid-cols-1 md:grid-cols-2 lg:grid-cols-3)
- Changed to vertical flex layout with flex-col
- Added max-w-4xl mx-auto to constrain width on large screens
- Reduced gap from gap-3 to gap-2 for more compact vertical spacing

Fixes #17

Generated with [Claude Code](https://claude.ai/code)