### PR TITLE
feat: Add sorting options to rankings page

### DIFF
--- a/src/components/PlayerRankings.tsx
+++ b/src/components/PlayerRankings.tsx
@@ -1,17 +1,27 @@
-import { Medal, Trophy } from 'lucide-react'
-import type { Player } from '@/types'
+import { ChevronDown, Medal, Trophy } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import type { Match, Player } from '@/types'
+
+type SortOption = 'elo' | 'goalDifference' | 'winRate'
 
 interface PlayerRankingsProps {
   players: Player[]
+  matches?: Match[]
   onPlayerClick?: (playerId: string) => void
 }
 
-interface PlayerCardProps {
-  player: Player
-  index: number
+interface PlayerWithStats extends Player {
+  goalDifference: number
+  winRate: number
 }
 
-const PlayerCard = ({ player, index }: PlayerCardProps) => (
+interface PlayerCardProps {
+  player: PlayerWithStats
+  index: number
+  sortBy: SortOption
+}
+
+const PlayerCard = ({ player, index, sortBy }: PlayerCardProps) => (
   <>
     <div className="flex items-center gap-3">
       <div className="flex items-center gap-2">
@@ -29,41 +39,200 @@ const PlayerCard = ({ player, index }: PlayerCardProps) => (
       </div>
     </div>
     <div className="text-right">
-      <span
-        className={`px-2 py-1 rounded-full text-xs font-bold ${
-          player.ranking >= 1800
-            ? 'bg-gradient-to-r from-purple-100 to-violet-200 text-purple-800'
-            : player.ranking >= 1600
-              ? 'bg-gradient-to-r from-emerald-100 to-green-200 text-emerald-800'
-              : player.ranking >= 1400
-                ? 'bg-gradient-to-r from-blue-100 to-cyan-200 text-blue-800'
-                : player.ranking >= 1200
-                  ? 'bg-gradient-to-r from-amber-100 to-yellow-200 text-amber-800'
-                  : 'bg-gradient-to-r from-rose-100 to-pink-200 text-rose-800'
-        }`}
-      >
-        {player.ranking}
-      </span>
-      <div className="text-xs text-slate-600 mt-1">
-        {player.matchesPlayed > 0
-          ? `${Math.round((player.wins / player.matchesPlayed) * 100)}% win rate`
-          : 'No matches'}
-      </div>
+      {sortBy === 'elo' && (
+        <>
+          <span
+            className={`px-2 py-1 rounded-full text-xs font-bold ${
+              player.ranking >= 1800
+                ? 'bg-gradient-to-r from-purple-100 to-violet-200 text-purple-800'
+                : player.ranking >= 1600
+                  ? 'bg-gradient-to-r from-emerald-100 to-green-200 text-emerald-800'
+                  : player.ranking >= 1400
+                    ? 'bg-gradient-to-r from-blue-100 to-cyan-200 text-blue-800'
+                    : player.ranking >= 1200
+                      ? 'bg-gradient-to-r from-amber-100 to-yellow-200 text-amber-800'
+                      : 'bg-gradient-to-r from-rose-100 to-pink-200 text-rose-800'
+            }`}
+          >
+            {player.ranking}
+          </span>
+          <div className="text-xs text-slate-600 mt-1">
+            {player.matchesPlayed > 0
+              ? `${Math.round((player.wins / player.matchesPlayed) * 100)}% win rate`
+              : 'No matches'}
+          </div>
+        </>
+      )}
+      {sortBy === 'goalDifference' && (
+        <>
+          <span
+            className={`px-2 py-1 rounded-full text-xs font-bold ${
+              player.goalDifference > 10
+                ? 'bg-gradient-to-r from-purple-100 to-violet-200 text-purple-800'
+                : player.goalDifference > 5
+                  ? 'bg-gradient-to-r from-emerald-100 to-green-200 text-emerald-800'
+                  : player.goalDifference > 0
+                    ? 'bg-gradient-to-r from-blue-100 to-cyan-200 text-blue-800'
+                    : player.goalDifference >= -5
+                      ? 'bg-gradient-to-r from-amber-100 to-yellow-200 text-amber-800'
+                      : 'bg-gradient-to-r from-rose-100 to-pink-200 text-rose-800'
+            }`}
+          >
+            {player.goalDifference > 0 ? '+' : ''}
+            {player.goalDifference}
+          </span>
+          <div className="text-xs text-slate-600 mt-1">Goal diff</div>
+        </>
+      )}
+      {sortBy === 'winRate' && (
+        <>
+          <span
+            className={`px-2 py-1 rounded-full text-xs font-bold ${
+              player.winRate >= 70
+                ? 'bg-gradient-to-r from-purple-100 to-violet-200 text-purple-800'
+                : player.winRate >= 60
+                  ? 'bg-gradient-to-r from-emerald-100 to-green-200 text-emerald-800'
+                  : player.winRate >= 50
+                    ? 'bg-gradient-to-r from-blue-100 to-cyan-200 text-blue-800'
+                    : player.winRate >= 40
+                      ? 'bg-gradient-to-r from-amber-100 to-yellow-200 text-amber-800'
+                      : 'bg-gradient-to-r from-rose-100 to-pink-200 text-rose-800'
+            }`}
+          >
+            {player.winRate}%
+          </span>
+          <div className="text-xs text-slate-600 mt-1">Win rate</div>
+        </>
+      )}
     </div>
   </>
 )
 
-const PlayerRankings = ({ players, onPlayerClick }: PlayerRankingsProps) => {
-  const sortedPlayers = [...players].sort((a, b) => b.ranking - a.ranking)
+const SORT_OPTIONS = [
+  { value: 'elo' as const, label: 'ELO Ranking' },
+  { value: 'goalDifference' as const, label: 'Goal Difference' },
+  { value: 'winRate' as const, label: 'Win Rate' },
+]
+
+const PlayerRankings = ({ players, matches = [], onPlayerClick }: PlayerRankingsProps) => {
+  const [sortBy, setSortBy] = useState<SortOption>('elo')
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+
+  // Load saved preference from localStorage
+  useEffect(() => {
+    const savedSort = localStorage.getItem('rankingSortPreference') as SortOption
+    if (savedSort && SORT_OPTIONS.some((opt) => opt.value === savedSort)) {
+      setSortBy(savedSort)
+    }
+  }, [])
+
+  // Save preference to localStorage
+  useEffect(() => {
+    localStorage.setItem('rankingSortPreference', sortBy)
+  }, [sortBy])
+
+  // Calculate additional stats for each player
+  const playersWithStats = useMemo(() => {
+    return players.map((player) => {
+      // Calculate goal difference from matches
+      const playerMatches = matches.filter(
+        (match) =>
+          match.team1[0].id === player.id ||
+          match.team1[1].id === player.id ||
+          match.team2[0].id === player.id ||
+          match.team2[1].id === player.id,
+      )
+
+      const goalDifference = playerMatches.reduce((diff, match) => {
+        const wasInTeam1 = match.team1[0].id === player.id || match.team1[1].id === player.id
+        const goalsFor = wasInTeam1 ? match.score1 : match.score2
+        const goalsAgainst = wasInTeam1 ? match.score2 : match.score1
+        return diff + (goalsFor - goalsAgainst)
+      }, 0)
+
+      const winRate =
+        player.matchesPlayed > 0 ? Math.round((player.wins / player.matchesPlayed) * 100) : 0
+
+      return {
+        ...player,
+        goalDifference,
+        winRate,
+      }
+    })
+  }, [players, matches])
+
+  // Sort players based on selected criteria
+  const sortedPlayers = useMemo(() => {
+    const sorted = [...playersWithStats]
+
+    switch (sortBy) {
+      case 'elo':
+        return sorted.sort((a, b) => b.ranking - a.ranking)
+      case 'goalDifference':
+        return sorted.sort((a, b) => {
+          // Sort by goal difference first, then by ELO as tiebreaker
+          if (b.goalDifference !== a.goalDifference) {
+            return b.goalDifference - a.goalDifference
+          }
+          return b.ranking - a.ranking
+        })
+      case 'winRate':
+        return sorted.sort((a, b) => {
+          // Sort by win rate first, then by matches played, then by ELO
+          if (b.winRate !== a.winRate) {
+            return b.winRate - a.winRate
+          }
+          if (b.matchesPlayed !== a.matchesPlayed) {
+            return b.matchesPlayed - a.matchesPlayed
+          }
+          return b.ranking - a.ranking
+        })
+      default:
+        return sorted
+    }
+  }, [playersWithStats, sortBy])
 
   return (
     <div className="bg-white/80 backdrop-blur-sm rounded-xl shadow-lg border border-white/50">
       <div className="p-4 border-b border-slate-200/50">
-        <h2 className="text-lg font-bold text-slate-800 flex items-center gap-2">
-          <Trophy className="text-orange-500" />
-          Friend Rankings
-        </h2>
-        <p className="text-sm text-slate-600">See how you stack up against your friends!</p>
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-slate-800 flex items-center gap-2">
+              <Trophy className="text-orange-500" />
+              Friend Rankings
+            </h2>
+            <p className="text-sm text-slate-600">See how you stack up against your friends!</p>
+          </div>
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setDropdownOpen(!dropdownOpen)}
+              className="px-3 py-1.5 bg-white border border-slate-200 rounded-lg text-sm font-medium text-slate-700 hover:bg-slate-50 flex items-center gap-1.5"
+            >
+              {SORT_OPTIONS.find((opt) => opt.value === sortBy)?.label}
+              <ChevronDown className="w-4 h-4" />
+            </button>
+            {dropdownOpen && (
+              <div className="absolute right-0 mt-1 w-44 bg-white rounded-lg shadow-lg border border-slate-200 z-10">
+                {SORT_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => {
+                      setSortBy(option.value)
+                      setDropdownOpen(false)
+                    }}
+                    className={`w-full text-left px-3 py-2 text-sm hover:bg-slate-50 first:rounded-t-lg last:rounded-b-lg ${
+                      sortBy === option.value ? 'bg-slate-50 font-medium' : ''
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
       </div>
 
       <div className="p-4">
@@ -77,14 +246,14 @@ const PlayerRankings = ({ players, onPlayerClick }: PlayerRankingsProps) => {
                 onClick={() => onPlayerClick(player.id)}
                 aria-label={`View match history for ${player.name}`}
               >
-                <PlayerCard player={player} index={index} />
+                <PlayerCard player={player} index={index} sortBy={sortBy} />
               </button>
             ) : (
               <div
                 key={player.id}
                 className="flex items-center justify-between bg-gradient-to-r from-white to-slate-50 p-3 rounded-lg border border-slate-200/50"
               >
-                <PlayerCard player={player} index={index} />
+                <PlayerCard player={player} index={index} sortBy={sortBy} />
               </div>
             ),
           )}

--- a/src/components/__tests__/PlayerRankings.test.tsx
+++ b/src/components/__tests__/PlayerRankings.test.tsx
@@ -61,9 +61,10 @@ describe('PlayerRankings', () => {
     expect(screen.getByText('7W - 3L (10 total)')).toBeInTheDocument()
   })
 
-  test('calculates and displays win rate correctly', () => {
+  test('calculates and displays win rate correctly when sorted by ELO', () => {
     render(<PlayerRankings players={mockPlayers} />)
 
+    // When sorted by ELO (default), it shows win rate as secondary info
     // Alice: 7/10 = 70%
     expect(screen.getByText('70% win rate')).toBeInTheDocument()
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,7 +15,7 @@ function Index() {
   const [showAddPlayer, setShowAddPlayer] = useState(false)
   const [showRecordMatch, setShowRecordMatch] = useState(false)
 
-  const { players, addPlayer, recordMatch } = useGameLogic()
+  const { players, matches, addPlayer, recordMatch } = useGameLogic()
 
   const handlePlayerCardClick = (playerId: string) => {
     navigate({
@@ -31,7 +31,7 @@ function Index() {
         onAddPlayer={() => setShowAddPlayer(true)}
       />
 
-      <PlayerRankings players={players} onPlayerClick={handlePlayerCardClick} />
+      <PlayerRankings players={players} matches={matches} onPlayerClick={handlePlayerCardClick} />
 
       <AddPlayerModal
         isOpen={showAddPlayer}


### PR DESCRIPTION
This PR implements sorting options for the rankings page as requested in #19.

## Changes
- Added dropdown menu to select sorting criteria (ELO, Goal Difference, Win Rate)
- Implemented sorting logic with appropriate tiebreakers
- Added localStorage persistence for selected sort option
- Updated UI to display relevant stats based on selected criteria
- Pass matches data to PlayerRankings component for calculations

Fixes #19

Generated with [Claude Code](https://claude.ai/code)