### PR TITLE
fix: prevent iOS scroll bounce on ranking history charts

### DIFF
--- a/src/components/charts/PlayerComparisonChart.tsx
+++ b/src/components/charts/PlayerComparisonChart.tsx
@@ -175,7 +175,7 @@ export function PlayerComparisonChart({
   const yDomain = [Math.max(800, minRanking - padding), Math.min(2400, maxRanking + padding)]
 
   const containerClass = needsScroll
-    ? 'overflow-x-auto overflow-y-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100'
+    ? 'overflow-x-auto overflow-y-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 -webkit-overflow-scrolling-touch'
     : ''
 
   return (
@@ -190,7 +190,13 @@ export function PlayerComparisonChart({
         })}
       </div>
 
-      <div ref={scrollRef} className={cn(containerClass)}>
+      <div
+        ref={scrollRef}
+        className={cn(containerClass)}
+        style={
+          needsScroll ? { WebkitOverflowScrolling: 'touch', overscrollBehaviorX: 'contain' } : {}
+        }
+      >
         {needsScroll && (
           <p className="text-xs text-gray-500 mb-2">
             ← Scroll left for match history. Showing all {chartData.length - 1} matches.

--- a/src/components/charts/RankingChart.tsx
+++ b/src/components/charts/RankingChart.tsx
@@ -118,11 +118,17 @@ export function RankingChart({ history, height = 250, className }: RankingChartP
   const yDomain = [Math.max(800, minRanking - padding), Math.min(2400, maxRanking + padding)]
 
   const containerClass = needsScroll
-    ? 'overflow-x-auto overflow-y-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100'
+    ? 'overflow-x-auto overflow-y-hidden scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 -webkit-overflow-scrolling-touch'
     : ''
 
   return (
-    <div ref={scrollRef} className={cn('bg-white rounded-lg', containerClass, className)}>
+    <div
+      ref={scrollRef}
+      className={cn('bg-white rounded-lg', containerClass, className)}
+      style={
+        needsScroll ? { WebkitOverflowScrolling: 'touch', overscrollBehaviorX: 'contain' } : {}
+      }
+    >
       <div
         style={{
           width: typeof chartWidth === 'number' ? `${chartWidth}px` : chartWidth,


### PR DESCRIPTION
Fixes #33

## Summary
- Prevents horizontal scroll bounce on iOS for ranking history graphs
- Applied iOS-specific CSS fixes to both RankingChart and PlayerComparisonChart components

## Changes
- Added `-webkit-overflow-scrolling-touch` for smooth iOS scrolling
- Added `overscrollBehaviorX: contain` to prevent bounce effect

## Test plan
- ✅ All existing tests pass (151 tests)
- ✅ Linting and format checks pass
- ✅ TypeScript compliance verified
- ✅ Production build successful

Generated with [Claude Code](https://claude.ai/code)