### PR TITLE
fix: improve mobile responsiveness of player profile banner

### DIFF
--- a/src/routes/players.$playerId.tsx
+++ b/src/routes/players.$playerId.tsx
@@ -294,16 +294,16 @@ function PlayerProfile() {
               ) : (
                 <>
                   <h1 className="text-2xl font-bold text-gray-900">{player.name}</h1>
-                  <div className="flex items-center space-x-3 mt-2">
+                  <div className="flex items-center space-x-2 sm:space-x-3 mt-2">
                     <span
                       className={cn(
-                        'px-3 py-1 rounded-full text-sm font-medium border',
+                        'px-2 sm:px-3 py-1 rounded-full text-xs sm:text-sm font-medium border whitespace-nowrap',
                         getRankingBadgeColor(player.ranking),
                       )}
                     >
                       {player.ranking} pts
                     </span>
-                    <span className="text-sm text-gray-500">
+                    <span className="text-xs sm:text-sm text-gray-500 whitespace-nowrap">
                       Rank #
                       {players
                         .sort((a, b) => b.ranking - a.ranking)
@@ -316,9 +316,9 @@ function PlayerProfile() {
           </div>
 
           {!isEditing && (
-            <Button onClick={startEdit} variant="outline" size="sm" className="whitespace-normal">
-              <Edit2 className="w-4 h-4 mr-1" />
-              Edit Profile
+            <Button onClick={startEdit} variant="outline" size="sm">
+              <Edit2 className="w-4 h-4 sm:mr-1" />
+              <span className="hidden sm:inline">Edit Profile</span>
             </Button>
           )}
         </div>


### PR DESCRIPTION
Fixes #39 - Profile banner on player profile page is not mobile friendly

## Changes
- Hide 'Edit Profile' text on mobile, show only icon
- Prevent points badge and rank text from wrapping on small screens
- Add responsive text sizes for better mobile display

Generated with [Claude Code](https://claude.ai/code)