### PR TITLE
fix: update test prop names to match component interfaces

### DIFF
--- a/src/components/__tests__/MatchHistory.test.tsx
+++ b/src/components/__tests__/MatchHistory.test.tsx
@@ -5,7 +5,7 @@ import type { Match, Player } from '@/types'
 import MatchHistory from '../MatchHistory'
 
 describe('MatchHistory', () => {
-  const mockOnRecordMatch = vi.fn()
+  const mockOnAddMatch = vi.fn()
 
   const mockPlayer1: Player = {
     id: 'player1',
@@ -61,7 +61,7 @@ describe('MatchHistory', () => {
 
   describe('Empty state', () => {
     it('renders empty state when no matches provided', () => {
-      render(<MatchHistory matches={[]} players={[]} onRecordMatch={mockOnRecordMatch} />)
+      render(<MatchHistory matches={[]} players={[]} onAddMatch={mockOnAddMatch} />)
 
       expect(screen.getByText('Recent Games')).toBeInTheDocument()
       expect(
@@ -69,15 +69,15 @@ describe('MatchHistory', () => {
       ).toBeInTheDocument()
     })
 
-    it('calls onRecordMatch when + button is clicked in empty state', async () => {
+    it('calls onAddMatch when + button is clicked in empty state', async () => {
       const user = userEvent.setup()
-      render(<MatchHistory matches={[]} players={[]} onRecordMatch={mockOnRecordMatch} />)
+      render(<MatchHistory matches={[]} players={[]} onAddMatch={mockOnAddMatch} />)
 
       const buttons = screen.getAllByRole('button')
       const addButton = buttons[1] // Second button is the add match button (+ icon)
       await user.click(addButton)
 
-      expect(mockOnRecordMatch).toHaveBeenCalledTimes(1)
+      expect(mockOnAddMatch).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -122,7 +122,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[matchWithRankingData]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -146,7 +146,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[matchWithRankingData]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -176,7 +176,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[matchWithRankingData]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -209,7 +209,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[legacyMatch]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -266,7 +266,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={matches}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -305,7 +305,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[matchWithZeroChange]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -346,7 +346,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[matchWithPositions]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -364,7 +364,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[matchWithPositions]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -410,7 +410,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={multipleMatches}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
         />,
       )
 
@@ -430,7 +430,7 @@ describe('MatchHistory', () => {
         <MatchHistory
           matches={[matchWithPositions]}
           players={[mockPlayer1, mockPlayer2, mockPlayer3, mockPlayer4]}
-          onRecordMatch={mockOnRecordMatch}
+          onAddMatch={mockOnAddMatch}
           onPlayerClick={mockOnPlayerClick}
         />,
       )

--- a/src/components/__tests__/QuickActions.test.tsx
+++ b/src/components/__tests__/QuickActions.test.tsx
@@ -4,45 +4,45 @@ import { vi } from 'vitest'
 import QuickActions from '../QuickActions'
 
 describe('QuickActions', () => {
-  const mockOnRecordMatch = vi.fn()
+  const mockOnAddMatch = vi.fn()
   const mockOnAddPlayer = vi.fn()
 
   beforeEach(() => {
-    mockOnRecordMatch.mockClear()
+    mockOnAddMatch.mockClear()
     mockOnAddPlayer.mockClear()
   })
 
   test('renders all action buttons', () => {
-    render(<QuickActions onRecordMatch={mockOnRecordMatch} onAddPlayer={mockOnAddPlayer} />)
+    render(<QuickActions onAddMatch={mockOnAddMatch} onAddPlayer={mockOnAddPlayer} />)
 
     expect(screen.getByText('Add Match')).toBeInTheDocument()
     expect(screen.getByText('Add Player')).toBeInTheDocument()
   })
 
-  test('calls onRecordMatch when Add Match button is clicked', async () => {
+  test('calls onAddMatch when Add Match button is clicked', async () => {
     const user = userEvent.setup()
-    render(<QuickActions onRecordMatch={mockOnRecordMatch} onAddPlayer={mockOnAddPlayer} />)
+    render(<QuickActions onAddMatch={mockOnAddMatch} onAddPlayer={mockOnAddPlayer} />)
 
     const recordButton = screen.getByRole('button', { name: /add match/i })
     await user.click(recordButton)
 
-    expect(mockOnRecordMatch).toHaveBeenCalledTimes(1)
+    expect(mockOnAddMatch).toHaveBeenCalledTimes(1)
     expect(mockOnAddPlayer).not.toHaveBeenCalled()
   })
 
   test('calls onAddPlayer when Add Player button is clicked', async () => {
     const user = userEvent.setup()
-    render(<QuickActions onRecordMatch={mockOnRecordMatch} onAddPlayer={mockOnAddPlayer} />)
+    render(<QuickActions onAddMatch={mockOnAddMatch} onAddPlayer={mockOnAddPlayer} />)
 
     const addButton = screen.getByRole('button', { name: /add player/i })
     await user.click(addButton)
 
     expect(mockOnAddPlayer).toHaveBeenCalledTimes(1)
-    expect(mockOnRecordMatch).not.toHaveBeenCalled()
+    expect(mockOnAddMatch).not.toHaveBeenCalled()
   })
 
   test('renders with correct icons', () => {
-    render(<QuickActions onRecordMatch={mockOnRecordMatch} onAddPlayer={mockOnAddPlayer} />)
+    render(<QuickActions onAddMatch={mockOnAddMatch} onAddPlayer={mockOnAddPlayer} />)
 
     // Check that buttons contain the expected text content
     const recordButton = screen.getByRole('button', { name: /add match/i })

--- a/src/hooks/__tests__/useGameLogic.test.ts
+++ b/src/hooks/__tests__/useGameLogic.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/services/playersService', () => ({
 vi.mock('@/services/matchesService', () => ({
   matchesService: {
     getMatchesByGroup: vi.fn().mockResolvedValue({ data: [] }),
-    recordMatch: vi.fn().mockResolvedValue({ data: null }),
+    addMatch: vi.fn().mockResolvedValue({ data: null }),
   },
 }))
 
@@ -52,7 +52,7 @@ describe('useGameLogic', () => {
     expect(result.current.loading).toBe(false)
     expect(result.current.error).toBeNull()
     expect(typeof result.current.addPlayer).toBe('function')
-    expect(typeof result.current.recordMatch).toBe('function')
+    expect(typeof result.current.addMatch).toBe('function')
   })
 
   test('addPlayer returns error when no group selected', async () => {
@@ -64,10 +64,10 @@ describe('useGameLogic', () => {
     expect(response.error).toBe('No group selected or user not authenticated')
   })
 
-  test('recordMatch returns error when no group selected', async () => {
+  test('addMatch returns error when no group selected', async () => {
     const { result } = renderHook(() => useGameLogic())
 
-    const response = await result.current.recordMatch('1', '2', '3', '4', '10', '5')
+    const response = await result.current.addMatch('1', '2', '3', '4', '10', '5')
 
     expect(response.success).toBe(false)
     expect(response.error).toBe('No group selected or user not authenticated')


### PR DESCRIPTION
Fixes #43

Fixed 4 failing tests by updating prop names to match component interfaces:
- Changed onRecordMatch to onAddMatch in QuickActions and MatchHistory tests
- Changed recordMatch to addMatch in useGameLogic tests to match hook API
- All 160 tests now pass successfully

Generated with [Claude Code](https://claude.ai/code)