### PR TITLE
fix: scope localStorage matchups to current group

### DIFF
--- a/src/components/MatchEntryModal.tsx
+++ b/src/components/MatchEntryModal.tsx
@@ -1,5 +1,6 @@
 import { Brain, History, Target, Users, X } from 'lucide-react'
 import { useState } from 'react'
+import { useGroupContext } from '@/contexts/GroupContext'
 import { savedMatchupsService } from '@/services/savedMatchupsService'
 import type { Match, Player } from '@/types'
 import { ManualTeamsWorkflow } from './ManualTeamsWorkflow'
@@ -24,7 +25,8 @@ type WorkflowMode = 'entry' | 'pick-teams' | 'manual-teams' | 'use-matchup'
 
 export const MatchEntryModal = ({ players, matches, addMatch, onClose }: MatchEntryModalProps) => {
   const [mode, setMode] = useState<WorkflowMode>('entry')
-  const savedMatchups = savedMatchupsService.getAllMatchups()
+  const { currentGroup } = useGroupContext()
+  const savedMatchups = currentGroup ? savedMatchupsService.getAllMatchups(currentGroup.id) : []
 
   const handleBack = () => {
     setMode('entry')
@@ -43,6 +45,7 @@ export const MatchEntryModal = ({ players, matches, addMatch, onClose }: MatchEn
         onBack={handleBack}
         onClose={onClose}
         onSuccess={handleSuccess}
+        groupId={currentGroup?.id || ''}
       />
     )
   }
@@ -55,6 +58,7 @@ export const MatchEntryModal = ({ players, matches, addMatch, onClose }: MatchEn
         onBack={handleBack}
         onClose={onClose}
         onSuccess={handleSuccess}
+        groupId={currentGroup?.id || ''}
       />
     )
   }

--- a/src/components/PickTeamsWorkflow.tsx
+++ b/src/components/PickTeamsWorkflow.tsx
@@ -21,6 +21,7 @@ interface PickTeamsWorkflowProps {
   onBack: () => void
   onClose: () => void
   onSuccess: () => void
+  groupId: string
 }
 
 type Step = 'selection' | 'result' | 'score'
@@ -32,6 +33,7 @@ export const PickTeamsWorkflow = ({
   onBack,
   onClose,
   onSuccess,
+  groupId,
 }: PickTeamsWorkflowProps) => {
   const [step, setStep] = useState<Step>('selection')
   const [matchmakingMode, setMatchmakingMode] = useState<'balanced' | 'rare'>('rare')
@@ -121,7 +123,7 @@ export const PickTeamsWorkflow = ({
       setMatchmakingResult(result)
 
       // Auto-save the matchup immediately
-      const savedMatchup = savedMatchupsService.saveMatchup(result, matchmakingMode)
+      const savedMatchup = savedMatchupsService.saveMatchup(result, matchmakingMode, groupId)
       setSavedMatchupId(savedMatchup.id)
 
       setStep('result')
@@ -181,7 +183,7 @@ export const PickTeamsWorkflow = ({
               onClick={() => {
                 // Remove the saved matchup when going back
                 if (savedMatchupId) {
-                  savedMatchupsService.deleteMatchup(savedMatchupId)
+                  savedMatchupsService.deleteMatchup(savedMatchupId, groupId)
                   setSavedMatchupId(null)
                 }
                 setStep('selection')
@@ -252,7 +254,7 @@ export const PickTeamsWorkflow = ({
               onClick={() => {
                 // Remove the previously saved matchup when regenerating
                 if (savedMatchupId) {
-                  savedMatchupsService.deleteMatchup(savedMatchupId)
+                  savedMatchupsService.deleteMatchup(savedMatchupId, groupId)
                   setSavedMatchupId(null)
                 }
                 setStep('selection')

--- a/src/components/UseMatchupWorkflow.tsx
+++ b/src/components/UseMatchupWorkflow.tsx
@@ -18,6 +18,7 @@ interface UseMatchupWorkflowProps {
   onBack: () => void
   onClose: () => void
   onSuccess: () => void
+  groupId: string
 }
 
 type Step = 'selection' | 'score'
@@ -28,6 +29,7 @@ export const UseMatchupWorkflow = ({
   onBack,
   onClose,
   onSuccess,
+  groupId,
 }: UseMatchupWorkflowProps) => {
   const [step, setStep] = useState<Step>('selection')
   const [selectedMatchup, setSelectedMatchup] = useState<SavedMatchup | null>(null)
@@ -41,7 +43,7 @@ export const UseMatchupWorkflow = ({
 
   const handleDeleteMatchup = (matchupId: string, event: React.MouseEvent) => {
     event.stopPropagation()
-    savedMatchupsService.deleteMatchup(matchupId)
+    savedMatchupsService.deleteMatchup(matchupId, groupId)
     setSavedMatchups((prev) => prev.filter((m) => m.id !== matchupId))
     toast().success('Matchup deleted')
   }
@@ -62,7 +64,7 @@ export const UseMatchupWorkflow = ({
     if (result.success) {
       toast().success('Match added successfully!')
       // Optionally delete the used matchup
-      savedMatchupsService.deleteMatchup(selectedMatchup.id)
+      savedMatchupsService.deleteMatchup(selectedMatchup.id, groupId)
       onSuccess()
     } else {
       toast().error(result.error || 'Failed to add match')


### PR DESCRIPTION
Fixes #47

## Summary
- Updated savedMatchupsService to accept groupId and use it in storage keys
- Modified all components using savedMatchupsService to pass current group ID
- Ensures matchup data is properly isolated between different groups

Generated with [Claude Code](https://claude.ai/code)