### PR TITLE
fix: hide online/offline text on small devices

### DIFF
--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -5,22 +5,25 @@ export const ConnectionStatus = () => {
   const { isOnline } = useOfflineStatus()
 
   return (
-    <div
+    <output
       className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-300 ${
         isOnline ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700 animate-pulse'
       }`}
+      aria-live="polite"
     >
       {isOnline ? (
         <>
-          <Cloud size={14} />
-          <span>Online</span>
+          <Cloud size={14} aria-hidden="true" />
+          <span className="hidden sm:inline">Online</span>
+          <span className="sr-only sm:hidden">Online</span>
         </>
       ) : (
         <>
-          <CloudOff size={14} />
-          <span>Offline</span>
+          <CloudOff size={14} aria-hidden="true" />
+          <span className="hidden sm:inline">Offline</span>
+          <span className="sr-only sm:hidden">Offline</span>
         </>
       )}
-    </div>
+    </output>
   )
 }


### PR DESCRIPTION
Fixes #52

Hides the "Online"/"Offline" text on small devices and shows only the icon with proper accessibility support.

## Changes
- Hide text on small screens using Tailwind responsive classes
- Show only icon on mobile devices with screen reader text
- Use semantic `<output>` element with aria-live for status updates
- Maintain visual text display on sm breakpoint and larger

Generated with [Claude Code](https://claude.ai/code)