### PR TITLE
fix: correct best and worst streak calculations in player profile

### DIFF
--- a/src/routes/players.$playerId.tsx
+++ b/src/routes/players.$playerId.tsx
@@ -12,6 +12,7 @@ import { useGameLogic } from '@/hooks/useGameLogic'
 import { usePositionStats } from '@/hooks/usePositionStats'
 import { useRankingHistory } from '@/hooks/useRankingHistory'
 import { scrollToTop } from '@/lib/utils'
+import { calculateStreaks } from '@/utils/streakCalculations'
 
 export const Route = createFileRoute('/players/$playerId')({
   component: PlayerProfile,
@@ -61,22 +62,11 @@ function PlayerProfile() {
       return won ? 'W' : 'L'
     })
 
-    // Win/loss streaks
-    let currentStreak = 0
-    let streakType: 'win' | 'loss' | null = null
-    for (const match of playerMatches) {
-      const wasInTeam1 = match.team1[0].id === playerId || match.team1[1].id === playerId
-      const won = wasInTeam1 ? match.score1 > match.score2 : match.score2 > match.score1
-
-      if (streakType === null) {
-        streakType = won ? 'win' : 'loss'
-        currentStreak = 1
-      } else if ((won && streakType === 'win') || (!won && streakType === 'loss')) {
-        currentStreak++
-      } else {
-        break
-      }
-    }
+    // Calculate win/loss streaks using utility function
+    const { currentStreak, streakType, bestStreak, worstStreak } = calculateStreaks(
+      playerId,
+      playerMatches,
+    )
 
     // Goals statistics
     const totalGoalsScored = playerMatches.reduce((sum, match) => {
@@ -115,6 +105,8 @@ function PlayerProfile() {
       recentForm,
       currentStreak,
       streakType,
+      bestStreak,
+      worstStreak,
       avgGoalsScored,
       avgGoalsConceded,
       goalDifference: totalGoalsScored - totalGoalsConceded,
@@ -177,8 +169,8 @@ function PlayerProfile() {
         goalsAgainst={parseInt(playerStats.avgGoalsConceded, 10) * playerStats.totalMatches}
         currentStreak={playerStats.currentStreak}
         streakType={playerStats.streakType}
-        bestStreak={playerStats.currentStreak} // Simplified for now
-        worstStreak={playerStats.currentStreak} // Simplified for now
+        bestStreak={playerStats.bestStreak}
+        worstStreak={playerStats.worstStreak}
       />
 
       {/* Additional Stats */}

--- a/src/utils/__tests__/streakCalculations.test.ts
+++ b/src/utils/__tests__/streakCalculations.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from 'vitest'
+import type { Match, Player } from '@/types'
+import { calculateStreaks } from '../streakCalculations'
+
+const createMockPlayer = (id: string, name: string): Player => ({
+  id,
+  name,
+  avatar: '👤',
+  ranking: 1200,
+  matchesPlayed: 10,
+  wins: 5,
+  losses: 5,
+  department: 'Engineering',
+  groupId: 'group1',
+  createdAt: '2024-01-01',
+})
+
+const createMockMatch = (
+  team1Player1: Player,
+  team1Player2: Player,
+  team2Player1: Player,
+  team2Player2: Player,
+  score1: number,
+  score2: number,
+): Match => ({
+  id: `match-${Date.now()}-${Math.random()}`,
+  team1: [team1Player1, team1Player2],
+  team2: [team2Player1, team2Player2],
+  score1,
+  score2,
+  date: '2024-01-01',
+  time: '12:00',
+  groupId: 'group1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+})
+
+describe('calculateStreaks', () => {
+  const player1 = createMockPlayer('1', 'Alice')
+  const player2 = createMockPlayer('2', 'Bob')
+  const player3 = createMockPlayer('3', 'Charlie')
+  const player4 = createMockPlayer('4', 'Diana')
+
+  describe('current streak calculation', () => {
+    it('should calculate a winning streak correctly', () => {
+      const matches: Match[] = [
+        // Most recent matches first (wins for player1)
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win (player1 in team1)
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win (player1 in team1)
+        createMockMatch(player1, player2, player3, player4, 10, 7), // Win (player1 in team1)
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss (player1 in team2, team1 wins)
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.currentStreak).toBe(3)
+      expect(result.streakType).toBe('win')
+    })
+
+    it('should calculate a losing streak correctly', () => {
+      const matches: Match[] = [
+        // Most recent matches first (losses for player1)
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 6), // Loss
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win (stops streak)
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.currentStreak).toBe(2)
+      expect(result.streakType).toBe('loss')
+    })
+
+    it('should handle single match', () => {
+      const matches: Match[] = [createMockMatch(player1, player2, player3, player4, 10, 5)]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.currentStreak).toBe(1)
+      expect(result.streakType).toBe('win')
+    })
+
+    it('should handle no matches', () => {
+      const matches: Match[] = []
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.currentStreak).toBe(0)
+      expect(result.streakType).toBe(null)
+      expect(result.bestStreak).toBe(0)
+      expect(result.worstStreak).toBe(0)
+    })
+  })
+
+  describe('best streak calculation', () => {
+    it('should find the longest winning streak in history', () => {
+      const matches: Match[] = [
+        // Current: 2 wins
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+        // Break
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        // Best streak: 5 wins
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 7), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 8), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 9), // Win
+        // Break
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        // Earlier: 3 wins
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 7), // Win
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.bestStreak).toBe(5)
+      expect(result.currentStreak).toBe(2)
+    })
+
+    it('should use current streak if it is the best', () => {
+      const matches: Match[] = [
+        // Current: 5 wins (also best)
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 7), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 8), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 9), // Win
+        // Break
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        // Earlier: 2 wins
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.bestStreak).toBe(5)
+      expect(result.currentStreak).toBe(5)
+      expect(result.streakType).toBe('win')
+    })
+
+    it('should handle all losses with no win streaks', () => {
+      const matches: Match[] = [
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 6), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 7), // Loss
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.bestStreak).toBe(0)
+      expect(result.currentStreak).toBe(3)
+      expect(result.streakType).toBe('loss')
+    })
+  })
+
+  describe('worst streak calculation', () => {
+    it('should find the longest losing streak in history', () => {
+      const matches: Match[] = [
+        // Current: 1 win
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        // Worst streak: 4 losses
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 6), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 7), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 8), // Loss
+        // Break
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        // Earlier: 2 losses
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 6), // Loss
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.worstStreak).toBe(4)
+      expect(result.currentStreak).toBe(1)
+      expect(result.streakType).toBe('win')
+    })
+
+    it('should use current streak if it is the worst', () => {
+      const matches: Match[] = [
+        // Current: 4 losses (also worst)
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 6), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 7), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 8), // Loss
+        // Break
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        // Earlier: 2 losses
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 6), // Loss
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.worstStreak).toBe(4)
+      expect(result.currentStreak).toBe(4)
+      expect(result.streakType).toBe('loss')
+    })
+
+    it('should handle all wins with no loss streaks', () => {
+      const matches: Match[] = [
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 7), // Win
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.worstStreak).toBe(0)
+      expect(result.currentStreak).toBe(3)
+      expect(result.streakType).toBe('win')
+    })
+  })
+
+  describe('complex scenarios', () => {
+    it('should handle alternating wins and losses', () => {
+      const matches: Match[] = [
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.currentStreak).toBe(1)
+      expect(result.streakType).toBe('win')
+      expect(result.bestStreak).toBe(1)
+      expect(result.worstStreak).toBe(1)
+    })
+
+    it('should correctly handle player in team2', () => {
+      const matches: Match[] = [
+        // Player1 in team2, team2 wins
+        createMockMatch(player3, player4, player1, player2, 5, 10), // Win for player1
+        createMockMatch(player3, player4, player1, player2, 6, 10), // Win for player1
+        createMockMatch(player3, player4, player1, player2, 7, 10), // Win for player1
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.currentStreak).toBe(3)
+      expect(result.streakType).toBe('win')
+      expect(result.bestStreak).toBe(3)
+    })
+
+    it('should handle the example from the issue (5 win streak, 4 loss streak)', () => {
+      const matches: Match[] = [
+        // Current: 2 wins
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+        // Break
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        // Best streak: 5 wins
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 6), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 7), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 8), // Win
+        createMockMatch(player1, player2, player3, player4, 10, 9), // Win
+        // Break - Worst streak: 4 losses
+        createMockMatch(player3, player4, player1, player2, 10, 5), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 6), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 7), // Loss
+        createMockMatch(player3, player4, player1, player2, 10, 8), // Loss
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.bestStreak).toBe(5)
+      expect(result.worstStreak).toBe(4)
+      // Current streak should be 2 wins (most recent)
+      expect(result.currentStreak).toBe(2)
+      expect(result.streakType).toBe('win')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle player not in any matches', () => {
+      const matches: Match[] = [
+        createMockMatch(player2, player3, player4, createMockPlayer('5', 'Eve'), 10, 5),
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      expect(result.currentStreak).toBe(0)
+      expect(result.streakType).toBe(null)
+      expect(result.bestStreak).toBe(0)
+      expect(result.worstStreak).toBe(0)
+    })
+
+    it('should handle draws (if score1 equals score2)', () => {
+      // In this implementation, draws are not possible as we check score1 > score2
+      // But this test ensures we don't crash with equal scores
+      const matches: Match[] = [
+        createMockMatch(player1, player2, player3, player4, 10, 10), // Draw treated as loss
+        createMockMatch(player1, player2, player3, player4, 10, 5), // Win
+      ]
+
+      const result = calculateStreaks('1', matches)
+
+      // Draw is treated as loss, so current streak should be 1 loss
+      expect(result.currentStreak).toBe(1)
+      expect(result.streakType).toBe('loss')
+    })
+  })
+})

--- a/src/utils/streakCalculations.ts
+++ b/src/utils/streakCalculations.ts
@@ -1,0 +1,87 @@
+import type { Match } from '@/types'
+
+export interface StreakData {
+  currentStreak: number
+  streakType: 'win' | 'loss' | null
+  bestStreak: number
+  worstStreak: number
+}
+
+/**
+ * Calculates streak statistics for a player based on their match history
+ * @param playerId - The ID of the player
+ * @param matches - Array of matches, ordered from most recent to oldest
+ * @returns Object containing current streak, streak type, best win streak, and worst loss streak
+ */
+export function calculateStreaks(playerId: string, matches: Match[]): StreakData {
+  let currentStreak = 0
+  let streakType: 'win' | 'loss' | null = null
+  let bestStreak = 0
+  let worstStreak = 0
+  let tempWinStreak = 0
+  let tempLossStreak = 0
+
+  // Calculate current streak (most recent matches)
+  for (const match of matches) {
+    const wasInTeam1 = match.team1[0].id === playerId || match.team1[1].id === playerId
+    const wasInTeam2 = match.team2[0].id === playerId || match.team2[1].id === playerId
+
+    // Skip matches where player was not involved
+    if (!wasInTeam1 && !wasInTeam2) {
+      continue
+    }
+
+    const won = wasInTeam1 ? match.score1 > match.score2 : match.score2 > match.score1
+
+    if (streakType === null) {
+      streakType = won ? 'win' : 'loss'
+      currentStreak = 1
+    } else if ((won && streakType === 'win') || (!won && streakType === 'loss')) {
+      currentStreak++
+    } else {
+      break
+    }
+  }
+
+  // Calculate best and worst streaks from all matches
+  for (const match of matches) {
+    const wasInTeam1 = match.team1[0].id === playerId || match.team1[1].id === playerId
+    const wasInTeam2 = match.team2[0].id === playerId || match.team2[1].id === playerId
+
+    // Skip matches where player was not involved
+    if (!wasInTeam1 && !wasInTeam2) {
+      continue
+    }
+
+    const won = wasInTeam1 ? match.score1 > match.score2 : match.score2 > match.score1
+
+    if (won) {
+      tempWinStreak++
+      if (tempLossStreak > worstStreak) {
+        worstStreak = tempLossStreak
+      }
+      tempLossStreak = 0
+    } else {
+      tempLossStreak++
+      if (tempWinStreak > bestStreak) {
+        bestStreak = tempWinStreak
+      }
+      tempWinStreak = 0
+    }
+  }
+
+  // Check final streaks
+  if (tempWinStreak > bestStreak) {
+    bestStreak = tempWinStreak
+  }
+  if (tempLossStreak > worstStreak) {
+    worstStreak = tempLossStreak
+  }
+
+  return {
+    currentStreak,
+    streakType,
+    bestStreak,
+    worstStreak,
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed incorrect best and worst streak calculations in player profile
- Created reusable `calculateStreaks` utility function with proper logic
- Added 15 comprehensive unit tests for streak calculations

## Changes
- Created `src/utils/streakCalculations.ts` with proper streak calculation logic
- Created `src/utils/__tests__/streakCalculations.test.ts` with 15 unit tests
- Updated `src/routes/players.$playerId.tsx` to use the new utility function

## Test Coverage
All tests passing (178 total, including 15 new streak tests)

Fixes #54

Generated with [Claude Code](https://claude.ai/code)