### PR TITLE
Fix win/lose streak order in Relationship widget

### DIFF
--- a/src/hooks/useRelationshipStats.ts
+++ b/src/hooks/useRelationshipStats.ts
@@ -28,15 +28,23 @@ export const useRelationshipStats = (
   players: Player[],
 ): RelationshipStatsData => {
   return useMemo(() => {
-    // Filter matches that include the target player
-    const playerMatches = matches.filter((match) => {
-      return (
-        match.team1[0].id === playerId ||
-        match.team1[1].id === playerId ||
-        match.team2[0].id === playerId ||
-        match.team2[1].id === playerId
-      )
-    })
+    // Filter matches that include the target player and sort by createdAt
+    const playerMatches = matches
+      .filter((match) => {
+        return (
+          match.team1[0].id === playerId ||
+          match.team1[1].id === playerId ||
+          match.team2[0].id === playerId ||
+          match.team2[1].id === playerId
+        )
+      })
+      .sort((a, b) => {
+        // Sort by createdAt in ascending order (oldest first)
+        // This ensures slice(-5) gets the most recent 5 games
+        const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0
+        const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0
+        return timeA - timeB
+      })
 
     // Maps to track stats
     const teammateStats = new Map<


### PR DESCRIPTION
Fixes #59

## Changes
- Sort matches by createdAt before processing to ensure correct chronological order
- This fixes the issue where the first 5 games were shown instead of the last 5
- Games are now displayed left-to-right with most recent on the right
- Updated test helper to support proper timestamp ordering
- Added new test to verify correct sorting with non-chronological input

## Testing
- All 185 tests pass
- Lint, format, and typecheck all pass

Generated with [Claude Code](https://claude.ai/code)