### PR TITLE
Fix: Create initial season when creating new groups

### DIFF
--- a/database/00_drop_and_create.sql
+++ b/database/00_drop_and_create.sql
@@ -215,6 +215,7 @@ AS $$
 DECLARE
   new_group_id uuid;
   new_invite_code text;
+  new_season_id uuid;
 BEGIN
   -- Create the group
   INSERT INTO friend_groups (name, description, owner_id, created_by)
@@ -225,11 +226,25 @@ BEGIN
   INSERT INTO group_memberships (group_id, user_id, role, is_active)
   VALUES (new_group_id, auth.uid(), 'owner', true);
 
+  -- Create initial season (Season 1) for the new group
+  INSERT INTO seasons (group_id, name, description, season_number, start_date, is_active, created_by)
+  VALUES (
+    new_group_id,
+    'Season 1',
+    'Initial season',
+    1,
+    CURRENT_DATE,
+    true,
+    auth.uid()
+  )
+  RETURNING id INTO new_season_id;
+
   RETURN json_build_object(
     'success', true,
     'group_id', new_group_id,
     'invite_code', new_invite_code,
-    'name', p_name
+    'name', p_name,
+    'season_id', new_season_id
   );
 END;
 $$;

--- a/database/migrations/009_fix_create_group_add_season.sql
+++ b/database/migrations/009_fix_create_group_add_season.sql
@@ -1,0 +1,52 @@
+-- Fix create_friend_group to automatically create Season 1 for new groups
+-- This fixes issue #68 where new groups don't have an initial season
+
+-- Drop and recreate the create_friend_group function
+DROP FUNCTION IF EXISTS create_friend_group(text, text);
+
+CREATE OR REPLACE FUNCTION create_friend_group(
+  p_name text,
+  p_description text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  new_group_id uuid;
+  new_invite_code text;
+  new_season_id uuid;
+BEGIN
+  -- Create the group
+  INSERT INTO friend_groups (name, description, owner_id, created_by)
+  VALUES (p_name, p_description, auth.uid(), auth.uid())
+  RETURNING id, invite_code INTO new_group_id, new_invite_code;
+
+  -- Add creator as owner member
+  INSERT INTO group_memberships (group_id, user_id, role, is_active)
+  VALUES (new_group_id, auth.uid(), 'owner', true);
+
+  -- Create initial season (Season 1) for the new group
+  INSERT INTO seasons (group_id, name, description, season_number, start_date, is_active, created_by)
+  VALUES (
+    new_group_id,
+    'Season 1',
+    'Initial season',
+    1,
+    CURRENT_DATE,
+    true,
+    auth.uid()
+  )
+  RETURNING id INTO new_season_id;
+
+  RETURN json_build_object(
+    'success', true,
+    'group_id', new_group_id,
+    'invite_code', new_invite_code,
+    'name', p_name,
+    'season_id', new_season_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION create_friend_group IS 'Creates a new friend group with an initial Season 1';

--- a/src/services/__tests__/groupCreationSeasons.test.ts
+++ b/src/services/__tests__/groupCreationSeasons.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createTestDatabase } from '@/test/test-database'
+import type { GroupCreationResult } from '@/types'
+
+class GroupService {
+  private db: import('@/lib/database').Database
+
+  constructor(db: import('@/lib/database').Database) {
+    this.db = db
+  }
+
+  async createGroup(name: string, description?: string): Promise<GroupCreationResult> {
+    const result = await this.db.createGroup(name, description)
+
+    if (result.error) {
+      return { success: false, error: result.error }
+    }
+
+    return {
+      success: result.data?.success ?? false,
+      groupId: result.data?.group_id ?? '',
+      inviteCode: result.data?.invite_code ?? '',
+      name: result.data?.name ?? '',
+    }
+  }
+}
+
+describe('Group Creation with Seasons', () => {
+  let fakeDb: ReturnType<typeof createTestDatabase>
+  let groupService: GroupService
+
+  beforeEach(() => {
+    fakeDb = createTestDatabase()
+    groupService = new GroupService(fakeDb)
+  })
+
+  it('should create an initial season (Season 1) when creating a new group', async () => {
+    // Create a new group
+    const result = await groupService.createGroup('Test Group', 'A test group')
+
+    // Verify group was created successfully
+    expect(result.success).toBe(true)
+    expect(result.groupId).toBeDefined()
+
+    // Verify that Season 1 was created for the group
+    const seasons = await fakeDb.getSeasonsByGroup(result.groupId ?? '')
+    expect(seasons.data).toHaveLength(1)
+    expect(seasons.data[0].name).toBe('Season 1')
+    expect(seasons.data[0].description).toBe('Initial season')
+    expect(seasons.data[0].seasonNumber).toBe(1)
+    expect(seasons.data[0].isActive).toBe(true)
+  })
+
+  it('should make the initial season active', async () => {
+    // Create a new group
+    const result = await groupService.createGroup('Test Group')
+
+    expect(result.success).toBe(true)
+
+    // Verify that there is an active season
+    const activeSeason = await fakeDb.getActiveSeason(result.groupId ?? '')
+    expect(activeSeason.data).not.toBeNull()
+    expect(activeSeason.data?.name).toBe('Season 1')
+    expect(activeSeason.data?.isActive).toBe(true)
+  })
+
+  it('should create season with correct metadata', async () => {
+    // Create a new group
+    const result = await groupService.createGroup('Test Group', 'A test group')
+
+    expect(result.success).toBe(true)
+
+    // Get the active season
+    const activeSeason = await fakeDb.getActiveSeason(result.groupId ?? '')
+    expect(activeSeason.data).not.toBeNull()
+
+    if (!activeSeason.data) {
+      throw new Error('Expected active season to be defined')
+    }
+
+    const season = activeSeason.data
+    // Verify season metadata
+    expect(season.groupId).toBe(result.groupId)
+    expect(season.name).toBe('Season 1')
+    expect(season.description).toBe('Initial season')
+    expect(season.seasonNumber).toBe(1)
+    expect(season.isActive).toBe(true)
+    expect(season.endDate).toBeNull()
+    expect(season.startDate).toBeDefined()
+  })
+
+  it('should allow retrieving season by group ID', async () => {
+    // Create two groups
+    const result1 = await groupService.createGroup('Group 1')
+    const result2 = await groupService.createGroup('Group 2')
+
+    // Get seasons for first group
+    const group1Seasons = await fakeDb.getSeasonsByGroup(result1.groupId ?? '')
+    expect(group1Seasons.data).toHaveLength(1)
+    expect(group1Seasons.data[0].groupId).toBe(result1.groupId)
+
+    // Get seasons for second group
+    const group2Seasons = await fakeDb.getSeasonsByGroup(result2.groupId ?? '')
+    expect(group2Seasons.data).toHaveLength(1)
+    expect(group2Seasons.data[0].groupId).toBe(result2.groupId)
+
+    // Verify they are different seasons
+    expect(group1Seasons.data[0].id).not.toBe(group2Seasons.data[0].id)
+  })
+})

--- a/src/test/fake-database.ts
+++ b/src/test/fake-database.ts
@@ -22,6 +22,9 @@ export class FakeDatabase implements Database {
   private memberships: GroupMembership[] = []
   private players: Player[] = []
   private matches: Match[] = []
+  private seasons: Season[] = []
+  // @ts-expect-error - Reserved for future implementation
+  private _playerSeasonStats: PlayerSeasonStats[] = []
   private nextId = 1
 
   private generateId(): string {
@@ -97,6 +100,24 @@ export class FakeDatabase implements Database {
       joinedAt: new Date().toISOString(),
       createdAt: new Date().toISOString(),
     })
+
+    // Create initial season (Season 1) for the new group
+    const seasonId = this.generateId()
+    const season: Season = {
+      id: seasonId,
+      groupId,
+      name: 'Season 1',
+      description: 'Initial season',
+      seasonNumber: 1,
+      startDate: new Date().toISOString().split('T')[0],
+      endDate: null,
+      isActive: true,
+      createdBy: 'fake-user-id',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+
+    this.seasons.push(season)
 
     const result: GroupCreationRpcResult = {
       success: true,
@@ -363,16 +384,19 @@ export class FakeDatabase implements Database {
     return { data: [], error: 'Not implemented in fake' }
   }
 
-  async getSeasonsByGroup(_groupId: string): Promise<DatabaseListResult<Season>> {
-    return { data: [], error: 'Not implemented in fake' }
+  async getSeasonsByGroup(groupId: string): Promise<DatabaseListResult<Season>> {
+    const seasons = this.seasons.filter((s) => s.groupId === groupId)
+    return { data: seasons, error: null }
   }
 
-  async getActiveSeason(_groupId: string): Promise<DatabaseResult<Season>> {
-    return { data: null, error: 'Not implemented in fake' }
+  async getActiveSeason(groupId: string): Promise<DatabaseResult<Season>> {
+    const season = this.seasons.find((s) => s.groupId === groupId && s.isActive)
+    return { data: season || null, error: null }
   }
 
-  async getSeasonById(_seasonId: string): Promise<DatabaseResult<Season>> {
-    return { data: null, error: 'Not implemented in fake' }
+  async getSeasonById(seasonId: string): Promise<DatabaseResult<Season>> {
+    const season = this.seasons.find((s) => s.id === seasonId)
+    return { data: season || null, error: null }
   }
 
   async endSeasonAndCreateNew(
@@ -421,6 +445,8 @@ export class FakeDatabase implements Database {
     this.memberships = []
     this.players = []
     this.matches = []
+    this.seasons = []
+    this._playerSeasonStats = []
     this.nextId = 1
   }
 
@@ -429,10 +455,14 @@ export class FakeDatabase implements Database {
     memberships?: GroupMembership[]
     players?: Player[]
     matches?: Match[]
+    seasons?: Season[]
+    playerSeasonStats?: PlayerSeasonStats[]
   }): void {
     if (data.groups) this.groups = [...data.groups]
     if (data.memberships) this.memberships = [...data.memberships]
     if (data.players) this.players = [...data.players]
     if (data.matches) this.matches = [...data.matches]
+    if (data.seasons) this.seasons = [...data.seasons]
+    if (data.playerSeasonStats) this._playerSeasonStats = [...data.playerSeasonStats]
   }
 }


### PR DESCRIPTION
## Summary

Fixes #68 - New groups are now automatically created with Season 1.

## Changes

- Updated `create_friend_group()` SQL function to create Season 1
- Created migration `009_fix_create_group_add_season.sql`
- Updated base schema in `00_drop_and_create.sql`
- Enhanced FakeDatabase to support seasons and create Season 1
- Added comprehensive test coverage for season creation

## Season 1 Properties

- Name: "Season 1"
- Description: "Initial season"
- Season number: 1
- Active: true
- Start date: Current date

## Tests

All 215 tests pass including 4 new tests that verify:
- Season 1 creation on new group creation
- Active season status
- Correct season metadata
- Season isolation between groups

## Quality Checks

- ✅ Linting passed
- ✅ TypeScript checks passed
- ✅ All tests passed

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/torryt/foos-and-friends/tree/claude/issue-68-20260114-0805) | [View job run](https://github.com/torryt/foos-and-friends/actions/runs/20986865185