### PR TITLE
feat: only show offline badge, hide badge when online

### DIFF
--- a/apps/chess/src/components/ConnectionStatus.tsx
+++ b/apps/chess/src/components/ConnectionStatus.tsx
@@ -1,29 +1,21 @@
-import { Cloud, CloudOff } from 'lucide-react'
+import { CloudOff } from 'lucide-react'
 import { useOfflineStatus } from '@/hooks/useOfflineStatus'
 
 export const ConnectionStatus = () => {
   const { isOnline } = useOfflineStatus()
 
+  if (isOnline) {
+    return null
+  }
+
   return (
     <output
-      className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-300 ${
-        isOnline ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700 animate-pulse'
-      }`}
+      className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-300 bg-red-100 text-red-700 animate-pulse"
       aria-live="polite"
     >
-      {isOnline ? (
-        <>
-          <Cloud size={14} aria-hidden="true" />
-          <span className="hidden sm:inline">Online</span>
-          <span className="sr-only sm:hidden">Online</span>
-        </>
-      ) : (
-        <>
-          <CloudOff size={14} aria-hidden="true" />
-          <span className="hidden sm:inline">Offline</span>
-          <span className="sr-only sm:hidden">Offline</span>
-        </>
-      )}
+      <CloudOff size={14} aria-hidden="true" />
+      <span className="hidden sm:inline">Offline</span>
+      <span className="sr-only sm:hidden">Offline</span>
     </output>
   )
 }

--- a/apps/chess/src/components/__tests__/ConnectionStatus.test.tsx
+++ b/apps/chess/src/components/__tests__/ConnectionStatus.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { ConnectionStatus } from '../ConnectionStatus'
+
+vi.mock('@/hooks/useOfflineStatus')
+
+import { useOfflineStatus } from '@/hooks/useOfflineStatus'
+
+const mockUseOfflineStatus = vi.mocked(useOfflineStatus)
+
+describe('ConnectionStatus', () => {
+  test('renders nothing when online', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: true })
+
+    const { container } = render(<ConnectionStatus />)
+
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByText('Online')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  test('renders offline badge when offline', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getAllByText('Offline').length).toBeGreaterThan(0)
+  })
+
+  test('does not render online badge when offline', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    expect(screen.queryByText('Online')).not.toBeInTheDocument()
+  })
+
+  test('offline badge has correct accessibility attributes', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    const output = screen.getByRole('status')
+    expect(output).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/apps/foosball/src/components/ConnectionStatus.tsx
+++ b/apps/foosball/src/components/ConnectionStatus.tsx
@@ -1,31 +1,21 @@
-import { Cloud, CloudOff } from 'lucide-react'
+import { CloudOff } from 'lucide-react'
 import { useOfflineStatus } from '@/hooks/useOfflineStatus'
 
 export const ConnectionStatus = () => {
   const { isOnline } = useOfflineStatus()
 
+  if (isOnline) {
+    return null
+  }
+
   return (
     <output
-      className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-300 ${
-        isOnline
-          ? 'bg-accent-subtle text-[var(--th-win)]'
-          : 'bg-card-hover text-[var(--th-loss)] animate-pulse'
-      }`}
+      className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-300 bg-card-hover text-[var(--th-loss)] animate-pulse"
       aria-live="polite"
     >
-      {isOnline ? (
-        <>
-          <Cloud size={14} aria-hidden="true" />
-          <span className="hidden sm:inline">Online</span>
-          <span className="sr-only sm:hidden">Online</span>
-        </>
-      ) : (
-        <>
-          <CloudOff size={14} aria-hidden="true" />
-          <span className="hidden sm:inline">Offline</span>
-          <span className="sr-only sm:hidden">Offline</span>
-        </>
-      )}
+      <CloudOff size={14} aria-hidden="true" />
+      <span className="hidden sm:inline">Offline</span>
+      <span className="sr-only sm:hidden">Offline</span>
     </output>
   )
 }

--- a/apps/foosball/src/components/__tests__/ConnectionStatus.test.tsx
+++ b/apps/foosball/src/components/__tests__/ConnectionStatus.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { ConnectionStatus } from '../ConnectionStatus'
+
+vi.mock('@/hooks/useOfflineStatus')
+
+import { useOfflineStatus } from '@/hooks/useOfflineStatus'
+
+const mockUseOfflineStatus = vi.mocked(useOfflineStatus)
+
+describe('ConnectionStatus', () => {
+  test('renders nothing when online', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: true })
+
+    const { container } = render(<ConnectionStatus />)
+
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByText('Online')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  test('renders offline badge when offline', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getAllByText('Offline').length).toBeGreaterThan(0)
+  })
+
+  test('does not render online badge when offline', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    expect(screen.queryByText('Online')).not.toBeInTheDocument()
+  })
+
+  test('offline badge has correct accessibility attributes', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    const output = screen.getByRole('status')
+    expect(output).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/apps/padel/src/components/ConnectionStatus.tsx
+++ b/apps/padel/src/components/ConnectionStatus.tsx
@@ -1,29 +1,21 @@
-import { Cloud, CloudOff } from 'lucide-react'
+import { CloudOff } from 'lucide-react'
 import { useOfflineStatus } from '@/hooks/useOfflineStatus'
 
 export const ConnectionStatus = () => {
   const { isOnline } = useOfflineStatus()
 
+  if (isOnline) {
+    return null
+  }
+
   return (
     <output
-      className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-300 ${
-        isOnline ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700 animate-pulse'
-      }`}
+      className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-300 bg-red-100 text-red-700 animate-pulse"
       aria-live="polite"
     >
-      {isOnline ? (
-        <>
-          <Cloud size={14} aria-hidden="true" />
-          <span className="hidden sm:inline">Online</span>
-          <span className="sr-only sm:hidden">Online</span>
-        </>
-      ) : (
-        <>
-          <CloudOff size={14} aria-hidden="true" />
-          <span className="hidden sm:inline">Offline</span>
-          <span className="sr-only sm:hidden">Offline</span>
-        </>
-      )}
+      <CloudOff size={14} aria-hidden="true" />
+      <span className="hidden sm:inline">Offline</span>
+      <span className="sr-only sm:hidden">Offline</span>
     </output>
   )
 }

--- a/apps/padel/src/components/__tests__/ConnectionStatus.test.tsx
+++ b/apps/padel/src/components/__tests__/ConnectionStatus.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { ConnectionStatus } from '../ConnectionStatus'
+
+vi.mock('@/hooks/useOfflineStatus')
+
+import { useOfflineStatus } from '@/hooks/useOfflineStatus'
+
+const mockUseOfflineStatus = vi.mocked(useOfflineStatus)
+
+describe('ConnectionStatus', () => {
+  test('renders nothing when online', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: true })
+
+    const { container } = render(<ConnectionStatus />)
+
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByText('Online')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  test('renders offline badge when offline', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getAllByText('Offline').length).toBeGreaterThan(0)
+  })
+
+  test('does not render online badge when offline', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    expect(screen.queryByText('Online')).not.toBeInTheDocument()
+  })
+
+  test('offline badge has correct accessibility attributes', () => {
+    mockUseOfflineStatus.mockReturnValue({ isOnline: false })
+
+    render(<ConnectionStatus />)
+
+    const output = screen.getByRole('status')
+    expect(output).toHaveAttribute('aria-live', 'polite')
+  })
+})


### PR DESCRIPTION
Removes the online badge from `ConnectionStatus` in all three apps. Now shows nothing when online, and only displays the offline badge when the user is offline.

Closes #88

Generated with [Claude Code](https://claude.ai/code)