### PR TITLE
feat: add foot and tree trunk emojis to avatar list

### DIFF
--- a/packages/shared/src/constants/avatars.ts
+++ b/packages/shared/src/constants/avatars.ts
@@ -140,6 +140,8 @@ export const AVAILABLE_AVATARS = [
   '🐢',
   '🐍',
   '🦎',
+  '🦶', // Foot
+  '🪵', // Tree trunk
 ]
 
 export const getRandomAvatar = (): string => {


### PR DESCRIPTION
Adds 🦶 (foot) and 🪵 (tree trunk) emojis to the `AVAILABLE_AVATARS` list in `packages/shared/src/constants/avatars.ts`.

Closes #90

Generated with [Claude Code](https://claude.ai/code)