### PR TITLE
fix: populate seasonId on matches loaded from Supabase

### DIFF
--- a/packages/shared/src/lib/supabase-database.ts
+++ b/packages/shared/src/lib/supabase-database.ts
@@ -135,6 +135,7 @@ const dbMatchToMatch = async (
     date: dbMatch.match_date,
     time: dbMatch.match_time,
     groupId: dbMatch.group_id,
+    seasonId: dbMatch.season_id,
     recordedBy: dbMatch.recorded_by,
     createdAt: dbMatch.created_at,
     playerStats,


### PR DESCRIPTION
## Summary
- `dbMatchToMatch` never copied `season_id` from the Supabase row onto the app-level `Match` object, so `match.seasonId` was always `undefined` for real data.
- The Ranking History chart's season view filters points by `seasonId === currentSeason.id`, which never matched, so it always showed "No matches in {season}" even when the player had played that season.
- Fix: add `seasonId: dbMatch.season_id` to the returned `Match` object.

Fixes #95

🤖 Generated with [Claude Code](https://claude.ai/code)