### PR TITLE
Add longest win/lose streak ranking filters

### DIFF
--- a/apps/chess/src/components/PlayerRankings.tsx
+++ b/apps/chess/src/components/PlayerRankings.tsx
@@ -1,12 +1,13 @@
-import type { Player, PlayerSeasonStats } from '@foos/shared'
+import type { Match, Player, PlayerSeasonStats } from '@foos/shared'
 import { ArrowUpDown, ChevronDown, Medal, Trophy } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 
-type SortOption = 'elo' | 'winRate'
+type SortOption = 'elo' | 'winRate' | 'longestWinStreak' | 'longestLoseStreak'
 
 interface PlayerRankingsProps {
   players: Player[]
   seasonStats?: PlayerSeasonStats[]
+  matches?: Match[]
   onPlayerClick?: (playerId: string) => void
   title?: string
   subtitle?: string
@@ -14,6 +15,52 @@ interface PlayerRankingsProps {
 
 interface PlayerWithStats extends Player {
   winRate: number
+  longestWinStreak: number
+  longestLoseStreak: number
+}
+
+// Computes the longest run of consecutive wins/losses from a player's match
+// history. Draws break both streaks without counting toward either.
+const computeStreaks = (
+  playerId: string,
+  matches: Match[],
+): { longestWinStreak: number; longestLoseStreak: number } => {
+  const playerMatches = matches
+    .filter(
+      (match) =>
+        match.team1[0].id === playerId ||
+        match.team1[1]?.id === playerId ||
+        match.team2[0].id === playerId ||
+        match.team2[1]?.id === playerId,
+    )
+    .toReversed() // oldest first
+
+  let longestWinStreak = 0
+  let longestLoseStreak = 0
+  let currentWinStreak = 0
+  let currentLoseStreak = 0
+
+  for (const match of playerMatches) {
+    const wasInTeam1 = match.team1[0].id === playerId || match.team1[1]?.id === playerId
+    const playerScore = wasInTeam1 ? match.score1 : match.score2
+    const opponentScore = wasInTeam1 ? match.score2 : match.score1
+
+    if (playerScore > opponentScore) {
+      currentWinStreak += 1
+      currentLoseStreak = 0
+    } else if (playerScore < opponentScore) {
+      currentLoseStreak += 1
+      currentWinStreak = 0
+    } else {
+      currentWinStreak = 0
+      currentLoseStreak = 0
+    }
+
+    longestWinStreak = Math.max(longestWinStreak, currentWinStreak)
+    longestLoseStreak = Math.max(longestLoseStreak, currentLoseStreak)
+  }
+
+  return { longestWinStreak, longestLoseStreak }
 }
 
 interface PlayerCardProps {
@@ -84,6 +131,46 @@ const PlayerCard = ({ player, index, sortBy }: PlayerCardProps) => (
           <div className="text-xs text-secondary mt-1">Win rate</div>
         </>
       )}
+      {sortBy === 'longestWinStreak' && (
+        <>
+          <span
+            className={`px-2 py-1 rounded-full text-xs font-bold ${
+              player.longestWinStreak >= 8
+                ? 'bg-gradient-to-r from-purple-100 to-violet-200 text-purple-800'
+                : player.longestWinStreak >= 5
+                  ? 'bg-gradient-to-r from-emerald-100 to-green-200 text-emerald-800'
+                  : player.longestWinStreak >= 3
+                    ? 'bg-gradient-to-r from-blue-100 to-cyan-200 text-blue-800'
+                    : player.longestWinStreak >= 1
+                      ? 'bg-gradient-to-r from-amber-100 to-yellow-200 text-amber-800'
+                      : 'bg-gradient-to-r from-rose-100 to-pink-200 text-rose-800'
+            }`}
+          >
+            {player.longestWinStreak}
+          </span>
+          <div className="text-xs text-secondary mt-1">Longest win streak</div>
+        </>
+      )}
+      {sortBy === 'longestLoseStreak' && (
+        <>
+          <span
+            className={`px-2 py-1 rounded-full text-xs font-bold ${
+              player.longestLoseStreak >= 8
+                ? 'bg-gradient-to-r from-purple-100 to-violet-200 text-purple-800'
+                : player.longestLoseStreak >= 5
+                  ? 'bg-gradient-to-r from-emerald-100 to-green-200 text-emerald-800'
+                  : player.longestLoseStreak >= 3
+                    ? 'bg-gradient-to-r from-blue-100 to-cyan-200 text-blue-800'
+                    : player.longestLoseStreak >= 1
+                      ? 'bg-gradient-to-r from-amber-100 to-yellow-200 text-amber-800'
+                      : 'bg-gradient-to-r from-rose-100 to-pink-200 text-rose-800'
+            }`}
+          >
+            {player.longestLoseStreak}
+          </span>
+          <div className="text-xs text-secondary mt-1">Longest lose streak</div>
+        </>
+      )}
     </div>
   </>
 )
@@ -91,11 +178,14 @@ const PlayerCard = ({ player, index, sortBy }: PlayerCardProps) => (
 const SORT_OPTIONS = [
   { value: 'elo' as const, label: 'ELO Ranking' },
   { value: 'winRate' as const, label: 'Win Rate' },
+  { value: 'longestWinStreak' as const, label: 'Longest Win Streak' },
+  { value: 'longestLoseStreak' as const, label: 'Longest Lose Streak' },
 ]
 
 const PlayerRankings = ({
   players,
   seasonStats,
+  matches = [],
   onPlayerClick,
   title = 'Friend Rankings',
   subtitle = 'See how you stack up against your friends!',
@@ -134,6 +224,7 @@ const PlayerRankings = ({
       const matchesPlayed = seasonScope ? (seasonStat?.matchesPlayed ?? 0) : player.matchesPlayed
 
       const winRate = matchesPlayed > 0 ? Math.round((wins / matchesPlayed) * 100) : 0
+      const { longestWinStreak, longestLoseStreak } = computeStreaks(player.id, matches)
 
       return {
         ...player,
@@ -142,9 +233,11 @@ const PlayerRankings = ({
         losses,
         matchesPlayed,
         winRate,
+        longestWinStreak,
+        longestLoseStreak,
       }
     })
-  }, [players, seasonStats])
+  }, [players, seasonStats, matches])
 
   // Sort players based on selected criteria
   const sortedPlayers = useMemo(() => {
@@ -161,6 +254,20 @@ const PlayerRankings = ({
           }
           if (b.matchesPlayed !== a.matchesPlayed) {
             return b.matchesPlayed - a.matchesPlayed
+          }
+          return b.ranking - a.ranking
+        })
+      case 'longestWinStreak':
+        return sorted.toSorted((a, b) => {
+          if (b.longestWinStreak !== a.longestWinStreak) {
+            return b.longestWinStreak - a.longestWinStreak
+          }
+          return b.ranking - a.ranking
+        })
+      case 'longestLoseStreak':
+        return sorted.toSorted((a, b) => {
+          if (b.longestLoseStreak !== a.longestLoseStreak) {
+            return b.longestLoseStreak - a.longestLoseStreak
           }
           return b.ranking - a.ranking
         })

--- a/apps/chess/src/components/__tests__/PlayerRankings.test.tsx
+++ b/apps/chess/src/components/__tests__/PlayerRankings.test.tsx
@@ -1,4 +1,4 @@
-import type { Player } from '@foos/shared'
+import type { Match, Player } from '@foos/shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import PlayerRankings from '../PlayerRankings'
 
@@ -172,6 +172,98 @@ describe('PlayerRankings', () => {
       render(<PlayerRankings players={mockPlayers} />)
 
       expect(screen.queryByText(/without games/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('sorting by streaks', () => {
+    // Alice (id 1) vs Bob (id 2), oldest to newest: L, W, W, W, L
+    // -> Alice: longest win streak 3, longest lose streak 1
+    // -> Bob (inverse results): longest win streak 1, longest lose streak 3
+    const streakMatches: Match[] = [
+      {
+        id: 'm5',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 5,
+        score2: 10,
+        date: '2024-01-05',
+        time: '10:00',
+      },
+      {
+        id: 'm4',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 10,
+        score2: 5,
+        date: '2024-01-04',
+        time: '10:00',
+      },
+      {
+        id: 'm3',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 10,
+        score2: 5,
+        date: '2024-01-03',
+        time: '10:00',
+      },
+      {
+        id: 'm2',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 10,
+        score2: 5,
+        date: '2024-01-02',
+        time: '10:00',
+      },
+      {
+        id: 'm1',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 5,
+        score2: 10,
+        date: '2024-01-01',
+        time: '10:00',
+      },
+    ]
+
+    test('sorts players by longest win streak', () => {
+      const { container } = render(<PlayerRankings players={mockPlayers} matches={streakMatches} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /Sort by/i }))
+      fireEvent.click(screen.getByText('Longest Win Streak'))
+
+      const playerNames = screen.getAllByText(/Alice Johnson|Bob Smith|Charlie Brown/)
+      expect(playerNames[0]).toHaveTextContent('Alice Johnson')
+      expect(playerNames[1]).toHaveTextContent('Bob Smith')
+      expect(playerNames[2]).toHaveTextContent('Charlie Brown')
+
+      const badges = container.querySelectorAll('.rounded-full')
+      expect(badges[0]).toHaveTextContent('3')
+      expect(badges[1]).toHaveTextContent('1')
+      expect(badges[2]).toHaveTextContent('0')
+    })
+
+    test('sorts players by longest lose streak', () => {
+      const { container } = render(<PlayerRankings players={mockPlayers} matches={streakMatches} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /Sort by/i }))
+      fireEvent.click(screen.getByText('Longest Lose Streak'))
+
+      const playerNames = screen.getAllByText(/Alice Johnson|Bob Smith|Charlie Brown/)
+      expect(playerNames[0]).toHaveTextContent('Bob Smith')
+      expect(playerNames[1]).toHaveTextContent('Alice Johnson')
+      expect(playerNames[2]).toHaveTextContent('Charlie Brown')
+
+      const badges = container.querySelectorAll('.rounded-full')
+      expect(badges[0]).toHaveTextContent('3')
+      expect(badges[1]).toHaveTextContent('1')
+      expect(badges[2]).toHaveTextContent('0')
     })
   })
 })

--- a/apps/chess/src/routes/index.tsx
+++ b/apps/chess/src/routes/index.tsx
@@ -19,7 +19,8 @@ function Index() {
   const [showRecordMatch, setShowRecordMatch] = useState(false)
   const [scope, setScope] = useState<RankingScope>('season')
 
-  const { players, seasonStats, matches, supportedMatchTypes, addPlayer, addMatch } = useGameLogic()
+  const { players, seasonStats, matches, allMatches, supportedMatchTypes, addPlayer, addMatch } =
+    useGameLogic()
   const { currentSeason, seasons } = useSeasonContext()
 
   const isArchived = !!currentSeason && !currentSeason.isActive
@@ -50,6 +51,7 @@ function Index() {
       <PlayerRankings
         players={players}
         seasonStats={allTime ? undefined : seasonStats}
+        matches={allTime ? allMatches : matches}
         onPlayerClick={handlePlayerCardClick}
         title={allTime ? 'All-Time Rankings' : isArchived ? 'Final Standings' : 'Friend Rankings'}
         subtitle={

--- a/apps/foosball/src/components/PlayerRankings.tsx
+++ b/apps/foosball/src/components/PlayerRankings.tsx
@@ -2,7 +2,7 @@ import type { Match, Player, PlayerSeasonStats } from '@foos/shared'
 import { ArrowUpDown, ChevronDown, Medal, Trophy } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 
-type SortOption = 'elo' | 'goalDifference' | 'winRate'
+type SortOption = 'elo' | 'goalDifference' | 'winRate' | 'longestWinStreak' | 'longestLoseStreak'
 
 interface PlayerRankingsProps {
   players: Player[]
@@ -16,6 +16,8 @@ interface PlayerRankingsProps {
 interface PlayerWithStats extends Player {
   goalDifference: number
   winRate: number
+  longestWinStreak: number
+  longestLoseStreak: number
 }
 
 interface PlayerCardProps {
@@ -39,12 +41,64 @@ const getTier = (sortBy: SortOption, player: PlayerWithStats): number => {
     if (player.goalDifference >= -5) return 4
     return 5
   }
-  // winRate
-  if (player.winRate >= 70) return 1
-  if (player.winRate >= 60) return 2
-  if (player.winRate >= 50) return 3
-  if (player.winRate >= 40) return 4
+  if (sortBy === 'winRate') {
+    if (player.winRate >= 70) return 1
+    if (player.winRate >= 60) return 2
+    if (player.winRate >= 50) return 3
+    if (player.winRate >= 40) return 4
+    return 5
+  }
+  // longestWinStreak / longestLoseStreak
+  const streak = sortBy === 'longestWinStreak' ? player.longestWinStreak : player.longestLoseStreak
+  if (streak >= 8) return 1
+  if (streak >= 5) return 2
+  if (streak >= 3) return 3
+  if (streak >= 1) return 4
   return 5
+}
+
+// Computes the longest run of consecutive wins/losses from a player's match
+// history. Draws (chess only) break both streaks without counting toward either.
+const computeStreaks = (
+  playerId: string,
+  matches: Match[],
+): { longestWinStreak: number; longestLoseStreak: number } => {
+  const playerMatches = matches
+    .filter(
+      (match) =>
+        match.team1[0].id === playerId ||
+        match.team1[1]?.id === playerId ||
+        match.team2[0].id === playerId ||
+        match.team2[1]?.id === playerId,
+    )
+    .toReversed() // oldest first
+
+  let longestWinStreak = 0
+  let longestLoseStreak = 0
+  let currentWinStreak = 0
+  let currentLoseStreak = 0
+
+  for (const match of playerMatches) {
+    const wasInTeam1 = match.team1[0].id === playerId || match.team1[1]?.id === playerId
+    const playerScore = wasInTeam1 ? match.score1 : match.score2
+    const opponentScore = wasInTeam1 ? match.score2 : match.score1
+
+    if (playerScore > opponentScore) {
+      currentWinStreak += 1
+      currentLoseStreak = 0
+    } else if (playerScore < opponentScore) {
+      currentLoseStreak += 1
+      currentWinStreak = 0
+    } else {
+      currentWinStreak = 0
+      currentLoseStreak = 0
+    }
+
+    longestWinStreak = Math.max(longestWinStreak, currentWinStreak)
+    longestLoseStreak = Math.max(longestLoseStreak, currentLoseStreak)
+  }
+
+  return { longestWinStreak, longestLoseStreak }
 }
 
 const TierBadge = ({ tier, children }: { tier: number; children: React.ReactNode }) => (
@@ -105,6 +159,18 @@ const PlayerCard = ({ player, index, sortBy }: PlayerCardProps) => {
             <div className="text-xs text-secondary mt-1">Win rate</div>
           </>
         )}
+        {sortBy === 'longestWinStreak' && (
+          <>
+            <TierBadge tier={tier}>{player.longestWinStreak}</TierBadge>
+            <div className="text-xs text-secondary mt-1">Longest win streak</div>
+          </>
+        )}
+        {sortBy === 'longestLoseStreak' && (
+          <>
+            <TierBadge tier={tier}>{player.longestLoseStreak}</TierBadge>
+            <div className="text-xs text-secondary mt-1">Longest lose streak</div>
+          </>
+        )}
       </div>
     </>
   )
@@ -114,6 +180,8 @@ const SORT_OPTIONS = [
   { value: 'elo' as const, label: 'ELO Ranking' },
   { value: 'goalDifference' as const, label: 'Goal Difference' },
   { value: 'winRate' as const, label: 'Win Rate' },
+  { value: 'longestWinStreak' as const, label: 'Longest Win Streak' },
+  { value: 'longestLoseStreak' as const, label: 'Longest Lose Streak' },
 ]
 
 const PlayerRankings = ({
@@ -182,6 +250,7 @@ const PlayerRankings = ({
       }
 
       const winRate = matchesPlayed > 0 ? Math.round((wins / matchesPlayed) * 100) : 0
+      const { longestWinStreak, longestLoseStreak } = computeStreaks(player.id, matches)
 
       return {
         ...player,
@@ -191,6 +260,8 @@ const PlayerRankings = ({
         matchesPlayed,
         goalDifference,
         winRate,
+        longestWinStreak,
+        longestLoseStreak,
       }
     })
   }, [players, seasonStats, matches])
@@ -218,6 +289,20 @@ const PlayerRankings = ({
           }
           if (b.matchesPlayed !== a.matchesPlayed) {
             return b.matchesPlayed - a.matchesPlayed
+          }
+          return b.ranking - a.ranking
+        })
+      case 'longestWinStreak':
+        return sorted.toSorted((a, b) => {
+          if (b.longestWinStreak !== a.longestWinStreak) {
+            return b.longestWinStreak - a.longestWinStreak
+          }
+          return b.ranking - a.ranking
+        })
+      case 'longestLoseStreak':
+        return sorted.toSorted((a, b) => {
+          if (b.longestLoseStreak !== a.longestLoseStreak) {
+            return b.longestLoseStreak - a.longestLoseStreak
           }
           return b.ranking - a.ranking
         })

--- a/apps/foosball/src/components/__tests__/PlayerRankings.test.tsx
+++ b/apps/foosball/src/components/__tests__/PlayerRankings.test.tsx
@@ -1,4 +1,4 @@
-import type { Player } from '@foos/shared'
+import type { Match, Player } from '@foos/shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import PlayerRankings from '../PlayerRankings'
 
@@ -172,6 +172,98 @@ describe('PlayerRankings', () => {
       render(<PlayerRankings players={mockPlayers} />)
 
       expect(screen.queryByText(/without games/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('sorting by streaks', () => {
+    // Alice (id 1) vs Bob (id 2), oldest to newest: L, W, W, W, L
+    // -> Alice: longest win streak 3, longest lose streak 1
+    // -> Bob (inverse results): longest win streak 1, longest lose streak 3
+    const streakMatches: Match[] = [
+      {
+        id: 'm5',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 5,
+        score2: 10,
+        date: '2024-01-05',
+        time: '10:00',
+      },
+      {
+        id: 'm4',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 10,
+        score2: 5,
+        date: '2024-01-04',
+        time: '10:00',
+      },
+      {
+        id: 'm3',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 10,
+        score2: 5,
+        date: '2024-01-03',
+        time: '10:00',
+      },
+      {
+        id: 'm2',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 10,
+        score2: 5,
+        date: '2024-01-02',
+        time: '10:00',
+      },
+      {
+        id: 'm1',
+        matchType: '1v1',
+        team1: [mockPlayers[0], null],
+        team2: [mockPlayers[1], null],
+        score1: 5,
+        score2: 10,
+        date: '2024-01-01',
+        time: '10:00',
+      },
+    ]
+
+    test('sorts players by longest win streak', () => {
+      const { container } = render(<PlayerRankings players={mockPlayers} matches={streakMatches} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /Sort by/i }))
+      fireEvent.click(screen.getByText('Longest Win Streak'))
+
+      const playerNames = screen.getAllByText(/Alice Johnson|Bob Smith|Charlie Brown/)
+      expect(playerNames[0]).toHaveTextContent('Alice Johnson')
+      expect(playerNames[1]).toHaveTextContent('Bob Smith')
+      expect(playerNames[2]).toHaveTextContent('Charlie Brown')
+
+      const badges = container.querySelectorAll('.rounded-full')
+      expect(badges[0]).toHaveTextContent('3')
+      expect(badges[1]).toHaveTextContent('1')
+      expect(badges[2]).toHaveTextContent('0')
+    })
+
+    test('sorts players by longest lose streak', () => {
+      const { container } = render(<PlayerRankings players={mockPlayers} matches={streakMatches} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /Sort by/i }))
+      fireEvent.click(screen.getByText('Longest Lose Streak'))
+
+      const playerNames = screen.getAllByText(/Alice Johnson|Bob Smith|Charlie Brown/)
+      expect(playerNames[0]).toHaveTextContent('Bob Smith')
+      expect(playerNames[1]).toHaveTextContent('Alice Johnson')
+      expect(playerNames[2]).toHaveTextContent('Charlie Brown')
+
+      const badges = container.querySelectorAll('.rounded-full')
+      expect(badges[0]).toHaveTextContent('3')
+      expect(badges[1]).toHaveTextContent('1')
+      expect(badges[2]).toHaveTextContent('0')
     })
   })
 })


### PR DESCRIPTION
Adds "Longest Win Streak" and "Longest Lose Streak" as new sort options in the rankings list, for both the foosball and chess apps.

Computed from each player's chronological match history: consecutive wins/losses are tracked, and a draw (chess only) breaks both streaks without counting toward either.

Closes #97.

Generated with [Claude Code](https://claude.ai/code)