### PR TITLE
fix: grow sibling header buttons to match bell's 44px touch target

### DIFF
--- a/apps/chess/src/components/GroupSelector.tsx
+++ b/apps/chess/src/components/GroupSelector.tsx
@@ -95,7 +95,7 @@ export const GroupSelector = ({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="bg-white/80 px-3 py-2 rounded-lg border border-white/50 hover:bg-white transition-colors flex items-center gap-2"
+        className="bg-white/80 px-3 py-2 min-h-11 rounded-lg border border-white/50 hover:bg-white transition-colors flex items-center gap-2"
         title={currentGroup ? `Current group: ${currentGroup.name}` : 'Select a group'}
       >
         <Users size={16} className="text-gray-600" />

--- a/apps/chess/src/components/Header.tsx
+++ b/apps/chess/src/components/Header.tsx
@@ -99,7 +99,7 @@ const Header = ({ user, onSignOut }: HeaderProps) => {
                           onGroupSettings={setGroupToEdit}
                         />
                       ) : (
-                        <div className="bg-card px-2 py-2 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)]">
+                        <div className="bg-card px-2 py-2 min-h-11 min-w-11 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)] flex items-center justify-center">
                           <Users size={16} className="text-secondary" />
                         </div>
                       )}
@@ -110,7 +110,7 @@ const Header = ({ user, onSignOut }: HeaderProps) => {
                       <button
                         type="button"
                         onClick={() => setShowProfileDropdown(!showProfileDropdown)}
-                        className="bg-card px-2 py-2 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)] hover:bg-card-hover transition-colors flex items-center gap-2"
+                        className="bg-card px-2 py-2 min-h-11 min-w-11 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)] hover:bg-card-hover transition-colors flex items-center justify-center gap-2"
                         title={user.email.split('@')[0]}
                       >
                         <User size={16} className="text-secondary" />

--- a/apps/foosball/src/components/GroupSelector.tsx
+++ b/apps/foosball/src/components/GroupSelector.tsx
@@ -92,7 +92,7 @@ export const GroupSelector = ({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="bg-card px-3 py-2 rounded-lg border border-[var(--th-border-subtle)] hover:bg-card-hover transition-colors flex items-center gap-2"
+        className="bg-card px-3 py-2 min-h-11 rounded-lg border border-[var(--th-border-subtle)] hover:bg-card-hover transition-colors flex items-center gap-2"
         title={currentGroup ? `Current group: ${currentGroup.name}` : 'Select a group'}
       >
         <Users size={16} className="text-secondary" />

--- a/apps/foosball/src/components/Header.tsx
+++ b/apps/foosball/src/components/Header.tsx
@@ -99,7 +99,7 @@ const Header = ({ user, onSignOut }: HeaderProps) => {
                           onGroupSettings={setGroupToEdit}
                         />
                       ) : (
-                        <div className="bg-card px-2 py-2 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)]">
+                        <div className="bg-card px-2 py-2 min-h-11 min-w-11 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)] flex items-center justify-center">
                           <Users size={16} className="text-secondary" />
                         </div>
                       )}
@@ -110,7 +110,7 @@ const Header = ({ user, onSignOut }: HeaderProps) => {
                       <button
                         type="button"
                         onClick={() => setShowProfileDropdown(!showProfileDropdown)}
-                        className="bg-card px-2 py-2 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)] hover:bg-card-hover transition-colors flex items-center gap-2"
+                        className="bg-card px-2 py-2 min-h-11 min-w-11 rounded-[var(--th-radius-md)] border border-[var(--th-border-subtle)] hover:bg-card-hover transition-colors flex items-center justify-center gap-2"
                         title={user.email.split('@')[0]}
                       >
                         <User size={16} className="text-secondary" />


### PR DESCRIPTION
## Summary
- Keeps the notification bell's `min-h-11 min-w-11` (44px) touch target — instead of shrinking it, grows the sibling header buttons (profile dropdown, group selector trigger, mobile group icon) to match, in both `apps/foosball` and `apps/chess`.
- Files: `Header.tsx` and `GroupSelector.tsx` in both apps.

Fixes #99

## Test plan
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm typecheck`
- [x] `pnpm test:run`
- [ ] Visual check in browser (not possible in this environment)

Generated with [Claude Code](https://claude.ai/code)